### PR TITLE
Fix amount display

### DIFF
--- a/src/modules/transaction/components/txnDataTables/TransferTxnDataTable.vue
+++ b/src/modules/transaction/components/txnDataTables/TransferTxnDataTable.vue
@@ -109,7 +109,7 @@
         <template #body="{data}">
           <div class="text-xs" v-if="data.amountTransfer">{{ Helper.toCurrencyFormat(data.amountTransfer, currencyDivisibility)}}</div>
           <div v-if="checkOtherAsset">
-            <div v-for="(sdaName, index) in displaySDAs(data.sda)" :key="index">{{sdaName.amount}}     
+            <div v-for="(sdaName, index) in displaySDAs(data.sda)" :key="index">{{Helper.toCurrencyFormat(sdaName.amount)}}     
             </div>
           </div>
         </template>


### PR DESCRIPTION
EXPL-106: Under Transfer tab, all amount value that in thousands should have "," in it.